### PR TITLE
External Jar Scanning

### DIFF
--- a/src/main/kotlin/me/devoxin/flight/FlightInfo.kt
+++ b/src/main/kotlin/me/devoxin/flight/FlightInfo.kt
@@ -1,5 +1,5 @@
 package me.devoxin.flight
 
 object FlightInfo {
-    val VERSION = "1.1.1"
+    val VERSION = "1.2.0"
 }

--- a/src/main/kotlin/me/devoxin/flight/api/CommandClientBuilder.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/CommandClientBuilder.kt
@@ -16,8 +16,7 @@ class CommandClientBuilder {
     private var parsers = hashMapOf<Class<*>, Parser<*>>()
     private var prefixes: List<String> = emptyList()
     private var allowMentionPrefix: Boolean = true
-    private var useDefaultHelpCommand: Boolean = true
-    private var showParameterTypes: Boolean = false
+    private var helpCommandConfig: DefaultHelpCommandConfig = DefaultHelpCommandConfig()
     private var ignoreBots: Boolean = true
     private var prefixProvider: PrefixProvider? = null
     private var eventListeners: MutableList<CommandClientAdapter> = mutableListOf()
@@ -67,9 +66,8 @@ class CommandClientBuilder {
      *
      * @return The builder instance. Useful for chaining.
      */
-    fun useDefaultHelpCommand(useDefaultHelpCommand: Boolean, showParameterTypes: Boolean = false): CommandClientBuilder {
-        this.useDefaultHelpCommand = useDefaultHelpCommand
-        this.showParameterTypes = showParameterTypes
+    fun configureDefaultHelpCommand(config: DefaultHelpCommandConfig.() -> Unit): CommandClientBuilder {
+        config(helpCommandConfig)
         return this
     }
 
@@ -158,8 +156,8 @@ class CommandClientBuilder {
         val prefixProvider = this.prefixProvider ?: DefaultPrefixProvider(prefixes, allowMentionPrefix)
         val commandClient = CommandClient(parsers, prefixProvider, ignoreBots, eventListeners.toList(), ownerIds)
 
-        if (useDefaultHelpCommand) {
-            commandClient.registerCommands(DefaultHelpCommand(showParameterTypes))
+        if (helpCommandConfig.enabled) {
+            commandClient.registerCommands(DefaultHelpCommand(helpCommandConfig.showParameterTypes))
         }
 
         return commandClient

--- a/src/main/kotlin/me/devoxin/flight/api/DefaultHelpCommandConfig.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/DefaultHelpCommandConfig.kt
@@ -1,0 +1,6 @@
+package me.devoxin.flight.api
+
+data class DefaultHelpCommandConfig(
+    var enabled: Boolean = true,
+    var showParameterTypes: Boolean = false
+)

--- a/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
+++ b/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
@@ -14,7 +14,7 @@ class ArgParser(
     private val delimiter: Char
 ) {
 
-    private var args = commandArgs.toMutableList()
+    private var args = commandArgs.toList()
 
     private fun getArgs(amount: Int): List<String> {
         if (args.isEmpty()) {
@@ -22,10 +22,7 @@ class ArgParser(
         }
 
         val taken = args.take(amount)
-
-        for (i in 0..amount) {
-            args.removeAt(0)
-        }
+        args = args.drop(amount) // I don't like re-assignment, so @todo figure out why .removeAt didn't work.
 
         return taken
     }

--- a/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
+++ b/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
@@ -22,7 +22,10 @@ class ArgParser(
         }
 
         val taken = args.take(amount)
-        args.drop(amount)
+
+        for (i in 0..amount) {
+            args.removeAt(0)
+        }
 
         return taken
     }

--- a/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
+++ b/src/main/kotlin/me/devoxin/flight/arguments/ArgParser.kt
@@ -24,6 +24,12 @@ class ArgParser(
         val taken = args.take(amount)
         args = args.drop(amount) // I don't like re-assignment, so @todo figure out why .removeAt didn't work.
 
+        /*
+        for (i in 0 until amount) {
+            args.removeAt(0)
+        }
+         */
+
         return taken
     }
 

--- a/src/main/kotlin/me/devoxin/flight/internal/CommandRegistry.kt
+++ b/src/main/kotlin/me/devoxin/flight/internal/CommandRegistry.kt
@@ -51,4 +51,29 @@ class CommandRegistry : HashMap<String, CommandWrapper>() {
         }
     }
 
+    /**
+     * Attempts to load the jar at the given path. If successful,
+     * Flight will attempt to discover all cogs in the jar, under the given package name.
+     *
+     * Before registering the cogs, any existing cogs whose names match those found in the jar will
+     * automatically be unregistered and removed.
+     *
+     * @param jarPath
+     *        A string-representation of the path to the jar file.
+     *
+     * @param packageName
+     *        The package name to scan for cogs/commands in.
+     */
+    fun reload(jarPath: String, packageName: String) {Indexer(packageName, jarPath).use {
+        val cogClasses = it.getCogs()
+
+        for (cls in cogClasses) {
+            val cog = cls.getDeclaredConstructor().newInstance()
+            removeByCog(cog.name())
+            registerCommands(cog, it)
+        }
+    }
+
+    }
+
 }

--- a/src/main/kotlin/me/devoxin/flight/internal/CommandRegistry.kt
+++ b/src/main/kotlin/me/devoxin/flight/internal/CommandRegistry.kt
@@ -1,0 +1,54 @@
+package me.devoxin.flight.internal
+
+import me.devoxin.flight.api.CommandWrapper
+import me.devoxin.flight.models.Cog
+import me.devoxin.flight.utils.Indexer
+
+class CommandRegistry : HashMap<String, CommandWrapper>() {
+
+    fun findCommandByName(name: String): CommandWrapper? {
+        return this[name]
+    }
+
+    fun findCommandByAlias(alias: String): CommandWrapper? {
+        return this.values.firstOrNull { it.properties.aliases.contains(alias) }
+    }
+
+    fun removeByCog(cogName: String, ignoreCase: Boolean = true) {
+        this.values.removeIf {
+            it.cog.name().equals(cogName, ignoreCase)
+        }
+    }
+
+    fun registerCommands(cog: Cog, indexer: Indexer? = null) {
+        val i = indexer ?: Indexer(cog::class.java.`package`.name)
+        val commands = i.getCommands(cog)
+
+        for (command in commands) {
+            val cmd = i.loadCommand(command, cog)
+            this[cmd.name] = cmd
+        }
+    }
+
+    fun registerCommands(packageName: String) {
+        val indexer = Indexer(packageName)
+        val cogs = indexer.getCogs()
+
+        for (cogClass in cogs) {
+            val cog = cogClass.getDeclaredConstructor().newInstance()
+            registerCommands(cog, indexer)
+        }
+    }
+
+    fun registerCommands(jarPath: String, packageName: String) {
+        Indexer(packageName, jarPath).use {
+            val cogClasses = it.getCogs()
+
+            for (cls in cogClasses) {
+                val cog = cls.getDeclaredConstructor().newInstance()
+                registerCommands(cog, it)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/me/devoxin/flight/utils/Indexer.kt
+++ b/src/main/kotlin/me/devoxin/flight/utils/Indexer.kt
@@ -37,8 +37,8 @@ class Indexer : Closeable {
         this.packageName = packageName
 
         val commandJar = File(jarPath)
-        check(commandJar.exists()) { "jarPath must lead to a valid jar file!" }
-        check(commandJar.extension == "jar") { "jarPath must lead to a valid jar file!" }
+        check(commandJar.exists()) { "jarPath points to a non-existent file." }
+        check(commandJar.extension == "jar") { "jarPath leads to a file which is not a jar." }
 
         val path = URL("jar:file:${commandJar.absolutePath}!/")
         this.classLoader = URLClassLoader.newInstance(arrayOf(path))


### PR DESCRIPTION
**Additions:**
• Loading commands from a `.jar`
• Unload commands by cog name

**Fixes:**
• Arg-parsing didn't consume arguments as it should.

**Changes:**
• Configuration of the DefaultHelpCommand is now a DSL. This should make it a little easier and cleaner to add more options in the future.

**Note:**
• The changes to DefaultHelpCommand could be breaking.
