### PR TITLE
Fix missing new line in buildCogHelp

### DIFF
--- a/src/main/kotlin/me/devoxin/flight/api/entities/DefaultHelpCommand.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/entities/DefaultHelpCommand.kt
@@ -88,7 +88,7 @@ open class DefaultHelpCommand(private val showParameterTypes: Boolean) : Cog {
     }
 
     open fun buildCogHelp(ctx: Context, cog: Cog): List<String> {
-        val builder = StringBuilder("Commands in ${cog::class.simpleName}")
+        val builder = StringBuilder("Commands in ${cog::class.simpleName}\n")
         val commands = ctx.commandClient.commands.findCommandsByCog(cog).filter { !it.properties.hidden }
         val padLength = ctx.commandClient.commands.values.maxBy { it.name.length }!!.name.length
 


### PR DESCRIPTION
Current output is missing the newline after showing cog name, current output:
![image](https://user-images.githubusercontent.com/46051820/86537656-1f50b480-bef1-11ea-9bab-4775c960791f.png)
Fixed output:
![image](https://user-images.githubusercontent.com/46051820/86537662-25469580-bef1-11ea-9734-837e7b071ec1.png)
