### PR TITLE
Update JDA to JDA5 alpha 22, fix classes after channel refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 dependencies {
     def kotlinVersion = '1.7.10'
     def coroutinesVersion = '1.6.4'
-    def jdaVersion = '5.0.0-alpha.18'
+    def jdaVersion = '5.0.0-alpha.22'
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion"

--- a/src/main/kotlin/me/devoxin/flight/api/CommandClientBuilder.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/CommandClientBuilder.kt
@@ -1,13 +1,17 @@
 package me.devoxin.flight.api
 
 import me.devoxin.flight.api.arguments.types.Emoji
-import me.devoxin.flight.api.entities.*
 import me.devoxin.flight.api.arguments.types.Invite
 import me.devoxin.flight.api.arguments.types.Snowflake
+import me.devoxin.flight.api.entities.*
 import me.devoxin.flight.api.hooks.CommandEventAdapter
 import me.devoxin.flight.internal.arguments.ArgParser
 import me.devoxin.flight.internal.parsers.*
-import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Role
+import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import java.net.URL
 import java.util.concurrent.ExecutorService
 

--- a/src/main/kotlin/me/devoxin/flight/api/context/Context.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/context/Context.kt
@@ -4,10 +4,10 @@ import me.devoxin.flight.api.CommandClient
 import me.devoxin.flight.internal.entities.Executable
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Guild
-import net.dv8tion.jda.api.entities.GuildMessageChannel
 import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.entities.MessageChannel
 import net.dv8tion.jda.api.entities.User
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import java.util.concurrent.CompletableFuture
 

--- a/src/main/kotlin/me/devoxin/flight/api/context/MessageContext.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/context/MessageContext.kt
@@ -7,6 +7,8 @@ import me.devoxin.flight.internal.utils.Scheduler
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.events.Event
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.requests.RestAction

--- a/src/main/kotlin/me/devoxin/flight/api/context/SlashContext.kt
+++ b/src/main/kotlin/me/devoxin/flight/api/context/SlashContext.kt
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.interactions.InteractionHook
-import net.dv8tion.jda.api.interactions.components.Modal
+import net.dv8tion.jda.api.interactions.modals.Modal
 import net.dv8tion.jda.api.utils.messages.MessageCreateData
 import net.dv8tion.jda.api.utils.messages.MessageEditData
 import java.util.concurrent.CompletableFuture

--- a/src/main/kotlin/me/devoxin/flight/internal/arguments/Argument.kt
+++ b/src/main/kotlin/me/devoxin/flight/internal/arguments/Argument.kt
@@ -2,6 +2,9 @@ package me.devoxin.flight.internal.arguments
 
 import me.devoxin.flight.api.annotations.Range
 import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel
 import net.dv8tion.jda.api.interactions.commands.OptionMapping
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import kotlin.reflect.KParameter

--- a/src/main/kotlin/me/devoxin/flight/internal/parsers/TextChannelParser.kt
+++ b/src/main/kotlin/me/devoxin/flight/internal/parsers/TextChannelParser.kt
@@ -1,7 +1,7 @@
 package me.devoxin.flight.internal.parsers
 
 import me.devoxin.flight.api.context.MessageContext
-import net.dv8tion.jda.api.entities.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import java.util.*
 
 class TextChannelParser : Parser<TextChannel> {

--- a/src/main/kotlin/me/devoxin/flight/internal/parsers/VoiceChannelParser.kt
+++ b/src/main/kotlin/me/devoxin/flight/internal/parsers/VoiceChannelParser.kt
@@ -1,7 +1,7 @@
 package me.devoxin.flight.internal.parsers
 
 import me.devoxin.flight.api.context.MessageContext
-import net.dv8tion.jda.api.entities.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 import java.util.*
 
 class VoiceChannelParser : Parser<VoiceChannel> {


### PR DESCRIPTION
After a class refractor that changed the code path of some classes, such as the *Channel entities, updating the JDA version was needed.